### PR TITLE
Added replace to prevent dashboard-login bug

### DIFF
--- a/frontend/src/components/Notes/Notes.js
+++ b/frontend/src/components/Notes/Notes.js
@@ -177,7 +177,7 @@ const Notes = () => {
 
     useEffect(() => {
       if (!sessionStorage.getItem('auth-token') || sessionStorage.getItem('auth-token') === "") {
-        navigate('/login');
+        navigate('/login', { replace: true });
       }
       else {
         setProgress(10);


### PR DESCRIPTION
## Describe your changes
On clicking dashboard without login the user is directed to login page but dashboard remains in browser history hence when we try to go back it again redirected to dashboard back again to login, I have added replace in replace in the dashboard login navigate without auth , this replaces the dashboard page with login page instead of just navigating to another change.
Now the bug is resolved .
## Screenshots - If Any (Optional)

##Issue #65 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

## Additional Information (Optional)
