### PR TITLE
Improve spacing on Info components

### DIFF
--- a/frontend/src/components/LandingPage/Components/Info/Info.css
+++ b/frontend/src/components/LandingPage/Components/Info/Info.css
@@ -2,11 +2,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 40px;
+    padding: 60px 10px;
 }
 
 .Info-section .grid {
-    gap: 4rem;
+    gap: 1rem;
     grid-template-columns: 1fr 1fr 1fr 1fr;
 }
 
@@ -15,7 +15,7 @@
 }
 
 .Info-section .About {
-    padding: 40px;
+    padding: 10px;
 }
 
 .Info-section h2 {
@@ -29,6 +29,7 @@
     text-align: center;
     color: var(--dark-color);
     padding: 10px;
+    max-width: 320px;
 }
 
 @media screen and (max-width:980px) {
@@ -43,7 +44,7 @@
     }
 
     .Info-section .About {
-        padding: 10px 40px;
+        padding: 10px;
     }
 }
 
@@ -56,7 +57,7 @@
 
 
     .Info-section .About {
-        padding: 10px 40px;
+        padding: 20px;
     }
 }
 
@@ -67,6 +68,6 @@
     }
 
     .Info-section .About {
-        padding: 10px 40px;
+        padding: 10px;
     }
 }


### PR DESCRIPTION
## Describe your changes

I changed the padding and gap properties in the `LandingPage/Info/Info.css` file.

And it also looks good on mobile!

## Screenshots - If Any (Optional)

How it looked before:
![image](https://user-images.githubusercontent.com/47185402/194731099-8765a011-f838-406a-aaa8-8f589c525cc9.png)

How it looks after the changes:
<img width="958" alt="image" src="https://user-images.githubusercontent.com/47185402/194731093-5875399c-ddc8-48c5-b357-39cc2ffc3ba2.png">


## Issue ticket number and link - #87 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

## Additional Information (Optional)
