### PR TITLE
fix: state after preview modal closes

### DIFF
--- a/frontend/src/components/Notes/Notes.js
+++ b/frontend/src/components/Notes/Notes.js
@@ -124,6 +124,8 @@ const Notes = () => {
 
     const closePreviewNoteModal = () => {
       document.getElementById('popup-box-preview').classList.remove('show');
+      setAddNoteTitle('');
+      setAddNoteDescription('');
     }
 
     const openAddMarkdownWindow = () =>{


### PR DESCRIPTION
## Describe your changes
State is not getting cleared after we close the preview and open add new note modal. Now inputs of add new note is blank everytime.
 
## Screenshots - If Any (Optional)
![1](https://user-images.githubusercontent.com/59108522/194885420-b68a3844-3dc2-44ca-a75a-aae2a52f32a1.png)
Click the notes card
![2](https://user-images.githubusercontent.com/59108522/194885408-e0cba545-5042-4404-b753-9c6fe05f3974.png)
After closing the preview modal and click add new note
![3](https://user-images.githubusercontent.com/59108522/194885397-9fdccda2-e9d9-4d75-9c03-16befd375aa0.png)

## Issue ticket number and link - If Any
Issue #116 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](https://github.com/dvstechlabs/Noteslify/blob/main/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

## Additional Information (Optional)
