### PR TITLE
Error handling for getNotes method - Fix #128

### DIFF
--- a/frontend/src/context/NotesContext.js
+++ b/frontend/src/context/NotesContext.js
@@ -3,115 +3,110 @@ import React, { createContext, useState } from 'react';
 const NotesContext = createContext({});
 
 export const NotesProvider = ({ children }) => {
-  const [notes, setNotes] = useState([]);
-  const token = sessionStorage.getItem('auth-token');
-  
-  const getNotes = async (search) => {
-    let response;
+    const [notes, setNotes] = useState([]);
+    const token = sessionStorage.getItem('auth-token');
 
-    if (!search) {
-      response = await fetch(`http://localhost:8181/api/notes/getallnotes`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'auth-token': token,
-        },
-      });
-    } else {
-      response = await fetch(
-        `http://localhost:8181/api/notes/search/${search}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'auth-token': token,
-          },
+    const getNotes = async (search) => {
+        let URI = 'http://localhost:8181/api/notes/getallnotes';
+        if (search) {
+            URI = `http://localhost:8181/api/notes/search/${search}`;
         }
-      );
-    }
+        try {
+            const response = await fetch(URI, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'auth-token': token,
+                },
+            });
 
-    const notes = await response.json();
-    setNotes(notes);
-  };
+            if (!response.ok) throw Error(response.status);
 
-  const getNote = async (note) => {
-    const response = await fetch(
-      `http://localhost:8181/api/notes/getnote/${note._id}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'auth-token': token,
-        },
-      }
+            const notes = await response.json();
+            setNotes(notes);
+        } catch (error) {
+            console.log('getNotes error: ', error);
+        }
+    };
+
+    const getNote = async (note) => {
+        const response = await fetch(
+            `http://localhost:8181/api/notes/getnote/${note._id}`,
+            {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'auth-token': token,
+                },
+            }
+        );
+
+        return await response.json();
+    };
+
+    const addNewNote = async (note) => {
+        const result = await fetch(`http://localhost:8181/api/notes/addnote`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'auth-token': token,
+            },
+            body: JSON.stringify(note),
+        });
+
+        return await result.json();
+    };
+
+    const updateExistingNote = async (note) => {
+        const response = await fetch(
+            `http://localhost:8181/api/notes/updatenote/${note._id}`,
+            {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'auth-token': token,
+                },
+                body: JSON.stringify({
+                    title: note.title,
+                    description: note.description,
+                }),
+            }
+        );
+
+        return await response.json();
+    };
+
+    const deleteNote = async (note) => {
+        const response = await fetch(
+            `http://localhost:8181/api/notes/deletenote/${note._id}`,
+            {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'auth-token': token,
+                },
+            }
+        );
+
+        return await response.json();
+    };
+
+    return (
+        <>
+            <NotesContext.Provider
+                value={{
+                    notes,
+                    getNotes,
+                    getNote,
+                    addNewNote,
+                    updateExistingNote,
+                    deleteNote,
+                }}
+            >
+                {children}
+            </NotesContext.Provider>
+        </>
     );
-
-    return await response.json();
-  };
-
-  const addNewNote = async (note) => {
-    const result = await fetch(`http://localhost:8181/api/notes/addnote`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'auth-token': token,
-      },
-      body: JSON.stringify(note),
-    });
-
-    return await result.json();
-  };
-
-  const updateExistingNote = async (note) => {
-    const response = await fetch(
-      `http://localhost:8181/api/notes/updatenote/${note._id}`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'auth-token': token,
-        },
-        body: JSON.stringify({
-          title: note.title,
-          description: note.description,
-        }),
-      }
-    );
-
-    return await response.json();
-  };
-
-  const deleteNote = async (note) => {
-    const response = await fetch(
-      `http://localhost:8181/api/notes/deletenote/${note._id}`,
-      {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          'auth-token': token,
-        },
-      }
-    );
-
-    return await response.json();
-  };
-
-  return (
-    <>
-      <NotesContext.Provider
-        value={{
-          notes,
-          getNotes,
-          getNote,
-          addNewNote,
-          updateExistingNote,
-          deleteNote,
-        }}
-      >
-        {children}
-      </NotesContext.Provider>
-    </>
-  );
 };
 
 export default NotesContext;


### PR DESCRIPTION
## Describe your changes
I added an error handling to getNotes method and also improved the code. When the request fails, it returns the error and sets the notes' state with the request error instead of an array. That is why it was broking the page.

The fix works, but the logic should be refactored since the first time logging in, the token is not ready yet, and the API call fails.
## Screenshots - If Any (Optional)

## Issue ticket number and link - If Any
#128
## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](https://github.com/dvstechlabs/Noteslify/blob/main/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

## Additional Information (Optional)
