### PR TITLE
mouse hover label on social media icon fixed

### DIFF
--- a/frontend/src/components/LandingPage/Components/Footer/Footer.js
+++ b/frontend/src/components/LandingPage/Components/Footer/Footer.js
@@ -17,11 +17,11 @@ const Footer = () => {
 
 
                     <div className="social">
-                        <a href="https://github.com/dvstechlabs/Noteslify"><i className="fa-brands fa-github-square"></i></a>
-                        <a href="#test"><i className="fa-brands fa-youtube-square"></i></a>
-                        <a href="#test"><i className="fa-brands fa-facebook-square"></i></a>
-                        <a href="#test"><i className="fa-brands fa-twitter-square"></i></a>
-                        <a href="#test"><i className="fa-brands fa-youtube-square"></i></a>
+                        <a title="github" href="https://github.com/dvstechlabs/Noteslify"><i className="fa-brands fa-github-square"></i></a>
+                        <a title="youtube" href="#test"><i className="fa-brands fa-youtube-square"></i></a>
+                        <a title="facebook" href="#test"><i className="fa-brands fa-facebook-square"></i></a>
+                        <a title="twitter" href="#test"><i className="fa-brands fa-twitter-square"></i></a>
+                        <a title="youtube" href="#test"><i className="fa-brands fa-youtube-square"></i></a>
                     </div>
 
                 </div>


### PR DESCRIPTION
Signed-off-by: Prakash <gatiyalap@gmail.com>

## Describe your changes
title(label) added for social media Icon at footer section. Now, User will be able to see social-media-AppName on mouse hover over social media Icon,
## Screenshots - If Any (Optional)
![image](https://user-images.githubusercontent.com/34413515/197353092-528eb0c8-dc22-4397-a83e-a6eda2487006.png)

## Issue ticket number and link - If Any
https://github.com/dvstechlabs/Noteslify/issues/182
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

- [X] Followed the repository's [Contributing Guidelines](https://github.com/dvstechlabs/Noteslify/blob/main/CONTRIBUTING.md).

- [X] I ran the app and tested it locally to verify that it works as expected.

- [X] I have starred the repository.

## Additional Information (Optional)
